### PR TITLE
Load schemas only when there is a schemaLocation attribute

### DIFF
--- a/src/BeSimple/SoapClient/WsdlDownloader.php
+++ b/src/BeSimple/SoapClient/WsdlDownloader.php
@@ -189,14 +189,16 @@ class WsdlDownloader
         $nodes = $xpath->query($query);
         if ($nodes->length > 0) {
             foreach ($nodes as $node) {
-                $schemaLocation = $node->getAttribute('schemaLocation');
-                if ($this->isRemoteFile($schemaLocation)) {
-                    $schemaLocation = $this->download($schemaLocation);
-                    $node->setAttribute('schemaLocation', $schemaLocation);
-                } elseif (!is_null($parentFile)) {
-                    $schemaLocation = $this->resolveRelativePathInUrl($parentFile, $schemaLocation);
-                    $schemaLocation = $this->download($schemaLocation);
-                    $node->setAttribute('schemaLocation', $schemaLocation);
+                if ( $node->hasAttribute('schemaLocation') ) {
+                    $schemaLocation = $node->getAttribute('schemaLocation');
+                    if ($this->isRemoteFile($schemaLocation)) {
+                        $schemaLocation = $this->download($schemaLocation);
+                        $node->setAttribute('schemaLocation', $schemaLocation);
+                    } elseif (!is_null($parentFile)) {
+                        $schemaLocation = $this->resolveRelativePathInUrl($parentFile, $schemaLocation);
+                        $schemaLocation = $this->download($schemaLocation);
+                        $node->setAttribute('schemaLocation', $schemaLocation);
+                    }
                 }
             }
         }

--- a/src/BeSimple/SoapClient/WsdlDownloader.php
+++ b/src/BeSimple/SoapClient/WsdlDownloader.php
@@ -189,12 +189,12 @@ class WsdlDownloader
         $nodes = $xpath->query($query);
         if ($nodes->length > 0) {
             foreach ($nodes as $node) {
-                if ( $node->hasAttribute('schemaLocation') ) {
+                if ($node->hasAttribute('schemaLocation')) {
                     $schemaLocation = $node->getAttribute('schemaLocation');
                     if ($this->isRemoteFile($schemaLocation)) {
                         $schemaLocation = $this->download($schemaLocation);
                         $node->setAttribute('schemaLocation', $schemaLocation);
-                    } elseif (!is_null($parentFile)) {
+                    } elseif (null !== $parentFile) {
                         $schemaLocation = $this->resolveRelativePathInUrl($parentFile, $schemaLocation);
                         $schemaLocation = $this->download($schemaLocation);
                         $node->setAttribute('schemaLocation', $schemaLocation);


### PR DESCRIPTION
Schemas should only be loaded when there is a schemaLocation attribute. Otherwise it will try to load a file with an empty file name from the same directory, which is the directory's index file (if it exists).
