### PR TITLE
Make CURLOPT_SSLVERSION configurable

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -113,6 +113,9 @@ class Curl
         if (isset($options['ca_path'])) {
             curl_setopt($this->ch, CURLOPT_CAPATH, $options['ca_path']);
         }
+        if (isset($options['ssl_version'])) {
+            curl_setopt($this->ch, CURLOPT_SSLVERSION, $options['ssl_version']);
+        }
     }
 
     /**


### PR DESCRIPTION
- [x] Allow a specific SSL/TLS version to be specified via the `options` array.
  Example:

``` php
use BeSimple\SoapClient\SoapClient as BeSimpleClient;

$client = new BeSimpleClient(
    'https://www.webservicex.net/geoipservice.asmx?WSDL',
    ['ssl_version' => CURL_SSLVERSION_TLSv1_2]
);
```
