### PR TITLE
proxy type Curl option added

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -90,6 +90,10 @@ class Curl
 
             curl_setopt($this->ch, CURLOPT_PROXY, $proxyHost);
 
+            if (!empty($options['proxy_type'])) {
+                curl_setopt($this->ch, CURLOPT_PROXYTYPE, $options['proxy_type']);
+            }
+
             if (false !== $proxyHost && isset($options['proxy_login'])) {
                 curl_setopt($this->ch, CURLOPT_PROXYUSERPWD, $options['proxy_login'].':'.$options['proxy_password']);
 


### PR DESCRIPTION
Without this option we cannot set any SOCKS proxy type, only default CURLPROXY_HTTP .